### PR TITLE
Adding correct module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module bookstack
+module github.com/j-saurabh/go-bookstacks
 
 go 1.16
 


### PR DESCRIPTION
The module was 'bookstack' but when we do a $go get <this_repo> then it gives error saying the module name should be same as the repository name. Hence, made the changes and commiting the same. 